### PR TITLE
Bump to 1.0.0, mapnik to 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # changelog
 
-## 0.3.0
+## 1.0.0
 
 - Updated to mapnik@3.7.0
+- Drops windows support
 
 ## 0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # changelog
 
+## 0.3.0
+
+- Updated to mapnik@3.7.0
+
 ## 0.2.0
 
 - Updated to mapnik@3.6.0

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/raster-tile-query",
   "description": "Raster tile query module",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "licenses": [
     {
       "type": "BSD"
@@ -23,7 +23,7 @@
   },
   "main": "./index",
   "dependencies": {
-    "mapnik": "~3.6.0",
+    "mapnik": "~3.7.0",
     "queue-async": "1.0.7",
     "sphericalmercator": "~1.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mapbox/raster-tile-query",
   "description": "Raster tile query module",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "licenses": [
     {
       "type": "BSD"


### PR DESCRIPTION
Bump to `1.0.0` due to dropping of windows support, mapnik to `3.7.0`